### PR TITLE
Remove blank first line to enable she-bang directive

### DIFF
--- a/prepare_adi_board_ip.sh
+++ b/prepare_adi_board_ip.sh
@@ -1,4 +1,3 @@
-  
 #!/bin/bash
 if [ "$#" -ne 2 ]; then
     echo "You must enter exactly 2 arguments: \$XILINX_DIR \$BOARD_NAME"


### PR DESCRIPTION
The prepare_adi_board_ip.sh currently doesn't work under zsh and possibly other non-bash shells because the she-bang is on the second line and not the first, which is currently blank. This fix deletes that blank first line